### PR TITLE
Fix for #28

### DIFF
--- a/minflux/yaml.py
+++ b/minflux/yaml.py
@@ -26,7 +26,7 @@ SCHEMA = vol.Schema({
     vol.Required(CONF_MINT): vol.Schema({
         vol.Optional(CONF_FILE): string,
         vol.Optional(CONF_DIR): string,
-        vol.Optional(CONF_ARCHIVE, default={}): vol.Any(
+        vol.Optional(CONF_ARCHIVE): vol.Any(
             vol.Schema({vol.Optional(CONF_DIR): string}), None
         )
     }),

--- a/tests/test_yaml.py
+++ b/tests/test_yaml.py
@@ -31,6 +31,7 @@ class TestYamlLoad(unittest.TestCase):
         self.assertTrue('influxdb' in x)
         self.assertTrue('mint' in x)
         self.assertTrue('file' in x['mint'])
+        self.assertFalse('archive' in x['mint'])
 
     def test_load_empty_yaml(self, mock_yaml_load, mock_isfile):
         """Tests loading of empty configuration."""


### PR DESCRIPTION
## Description:
Removed default from `archive:` entry to prevent archiving even though it wasn't configured.

**Related issue (if applicable):** fixes #28

 